### PR TITLE
Add support for strings, arrays and hash literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.so
 *.dylib
 
+# Code Counter
+*.VSCodeCounter
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ let cyrus = { name: "Cyrus", age: 26 };
 numArray[0]; // 1
 
 // Accessing property values in hashes
-cyrus("name"); // Cyrus
+cyrus["name"]; // Cyrus
 ```
 
 - The `let` keyword is used to declare variables in Chui, above is how we bind variables to values, and some Data Structures. `let` can also be used to bind function names.
@@ -502,4 +502,9 @@ _ Its worth noting the following code:
 1. Get the previously associated number for an identifier.
 
 - The common names for these twwo methods on the symbol table are `Define` and `Resolve`. `Define` is used to bind a name to a value in a given scope, and `Resolve` is used to look up the value associated with a name. The information is known as the symbol - an identifier is associated with a symbol and the symbol contains the information. 
-. 
+
+## String, Array and Hash
+
+### Strings
+- In this [PR #5](https://github.com/Cyrus-0101/chui/pull/5), we will focus on adding support for string, array and hash literals. We will be able to create and manipulate strings, arrays and hashes in Chui. Just as similar in Integer literals, we can turn them into `*object.String` at compile time and add them to the constant pool in `compiler.Bytecode`. This means we can implemement string concatenation simulataneously.
+

--- a/README.md
+++ b/README.md
@@ -508,3 +508,24 @@ _ Its worth noting the following code:
 ### Strings
 - In this [PR #5](https://github.com/Cyrus-0101/chui/pull/5), we will focus on adding support for string, array and hash literals. We will be able to create and manipulate strings, arrays and hashes in Chui. Just as similar in Integer literals, we can turn them into `*object.String` at compile time and add them to the constant pool in `compiler.Bytecode`. This means we can implemement string concatenation simulataneously.
 
+### Arrays
+- Arrays in Chui will be our first [composite data type](https://en.wikipedia.org/wiki/Composite_data_type). This means, generally, arrays are composed out of other data types. The downside is we cannot treat array literals as constants, since they can be modified at runtime. Here's an example:
+
+```shell
+    [1 + 2, 3 + 4, 5 + 6]
+```
+
+- An optimising compiler, could easily optimise these, but they can include: `integer literals`, `string concatenation`, `function literals`, `function calls` etc. Only at run time, can we determine what they evaluate to. 
+- Instead of building an array at compile time and passing it to the VM in the constant pool, we'll tell the VM how to build its own. We will have to create a new instruction `OpArray` to create arrays at runtime. We will also have to create a new instruction `OpIndex` to access elements in an array.
+
+-Since these are `*ast.Expressions`, compiling thme results in instructions that leave N values on the VM's stack, where N is the Number of elements in the array literal. We then emit `OpArray` instruction with the operand being N, the number of elements. When the VM encounters `OpArray`, it will pop N values from the stack, and create an `*object.Array` with those values.
+
+### Hashes
+- Similarly, we need a new OpCOde, just like in an array, its final value can be determined at compile time. Actually doubke the case, since `Chui`'s hash has N keys and N values and all of them are created by expressions:
+
+```shell
+    {1 + 1: 2 * 2, 3 + 3: 4 * 4}
+    # {2: 4, 6: 16}
+```
+
+- We will introduce a new instruction `OpHash` to create hashes at runtime. We will also introduce a new instruction `OpIndex` to access elements in a hash. The `OpIndex` instruction will be used to look up values in hashes by their keys. but we'll deal with that in a seperate commit.

--- a/src/code/code.go
+++ b/src/code/code.go
@@ -32,6 +32,7 @@ const (
 	OpNull
 	OpGetGlobal
 	OpSetGlobal
+	OpArray
 )
 
 // Definition represents the definition of an opcode, including its name and the widths of its operands, which is used to determine how many bytes to read to extract the operands.
@@ -60,6 +61,7 @@ var definitions = map[Opcode]*Definition{
 	OpNull:          {"OpNull", []int{}},
 	OpGetGlobal:     {"OpGetGlobal", []int{2}},
 	OpSetGlobal:     {"OpSetGlobal", []int{2}},
+	OpArray:         {"OpArray", []int{2}},
 }
 
 // Lookup() retrieves the definition of an opcode.

--- a/src/code/code.go
+++ b/src/code/code.go
@@ -33,6 +33,8 @@ const (
 	OpGetGlobal
 	OpSetGlobal
 	OpArray
+	OpIndex
+	OpHash
 )
 
 // Definition represents the definition of an opcode, including its name and the widths of its operands, which is used to determine how many bytes to read to extract the operands.
@@ -62,6 +64,8 @@ var definitions = map[Opcode]*Definition{
 	OpGetGlobal:     {"OpGetGlobal", []int{2}},
 	OpSetGlobal:     {"OpSetGlobal", []int{2}},
 	OpArray:         {"OpArray", []int{2}},
+	OpIndex:         {"OpIndex", []int{2}},
+	OpHash:          {"OpHash", []int{2}},
 }
 
 // Lookup() retrieves the definition of an opcode.

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -142,6 +142,10 @@ func (c *Compiler) Compile(node ast.Node) error {
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))
 
+	case *ast.StringLiteral:
+		str := &object.String{Value: node.Value}
+		c.emit(code.OpConstant, c.addConstant((str)))
+
 	case *ast.BlockStatement:
 		for _, s := range node.Statements {
 			err := c.Compile(s)

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -38,7 +38,7 @@ func NewWithState(s *SymbolTable, constants []object.Object) *Compiler {
 	return compiler
 }
 
-// Compile() - A struct that holds the state of the compiler including generated instructions, alist of constants and the last two instructions emitted.
+// Compile() - A struct that holds the state of the compiler including generated instructions, a list of constants and the last two instructions emitted.
 // It compiles an AST node into bytecode instructions.
 func (c *Compiler) Compile(node ast.Node) error {
 	switch node := node.(type) {
@@ -210,6 +210,17 @@ func (c *Compiler) Compile(node ast.Node) error {
 		}
 
 		c.emit(code.OpGetGlobal, symbol.Index)
+
+	case *ast.ArrayLiteral:
+		for _, el := range node.Elements {
+			err := c.Compile(el)
+			if err != nil {
+				return err
+			}
+		}
+
+		c.emit(code.OpArray, len(node.Elements))
+
 	}
 
 	return nil

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -8,6 +8,7 @@ import (
 	"chui/code"
 	"chui/object"
 	"fmt"
+	"sort"
 )
 
 // Compiler is the compiler struct - it holds the bytecode instructions and the constant pool.
@@ -220,6 +221,33 @@ func (c *Compiler) Compile(node ast.Node) error {
 		}
 
 		c.emit(code.OpArray, len(node.Elements))
+
+	case *ast.HashLiteral:
+		keys := []ast.Expression{}
+
+		for k := range node.Pairs {
+			keys = append(keys, k)
+		}
+
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i].String() < keys[j].String()
+		})
+
+		for _, k := range keys {
+			err := c.Compile(k)
+			if err != nil {
+				return err
+			}
+
+			err = c.Compile(node.Pairs[k])
+			if err != nil {
+				return err
+			}
+		}
+
+		c.emit(code.OpHash, len(node.Pairs)*2)
+
+	case *ast.IndexExpression:
 
 	}
 

--- a/src/compiler/compiler_test.go
+++ b/src/compiler/compiler_test.go
@@ -291,6 +291,30 @@ func TestGlobalLetStatements(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestStringExpressions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `"chui"`,
+			expectedConstants: []interface{}{"chui"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `"ch" + "ui"`,
+			expectedConstants: []interface{}{"ch", "ui"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTests(t, tests)
+}
+
 func parse(input string) *ast.Program {
 	l := lexer.New(input)
 	p := parser.New(l)
@@ -372,8 +396,28 @@ func testConstants(
 				return fmt.Errorf("constant %d - testIntegerObject failed: %s",
 					i, err)
 			}
+
+		case string:
+			err := testStringObject(constant, actual[i])
+			if err != nil {
+				return fmt.Errorf("constant %d - testStringObject failed: %s",
+					i, err)
+			}
 		}
 	}
+	return nil
+}
+
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+	if !ok {
+		return fmt.Errorf("object is not a string, got=%T (%+v)", actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value, got=%q, want=%q", result.Value, expected)
+	}
+
 	return nil
 }
 

--- a/src/compiler/compiler_test.go
+++ b/src/compiler/compiler_test.go
@@ -315,6 +315,48 @@ func TestStringExpressions(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestArrayLiterals(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "[]",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "[1, 2, 3]",
+			expectedConstants: []interface{}{1, 2, 3},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpArray, 3),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "[1 + 2, 3 - 4, 5 * 6]",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpSub),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpMul),
+				code.Make(code.OpArray, 3),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTests(t, tests)
+}
+
 func parse(input string) *ast.Program {
 	l := lexer.New(input)
 	p := parser.New(l)

--- a/src/compiler/compiler_test.go
+++ b/src/compiler/compiler_test.go
@@ -357,6 +357,50 @@ func TestArrayLiterals(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestHashLiterals(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "{}",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpHash, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "{1: 2, 3: 4, 5: 6}",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpHash, 6),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "{1: 2 + 3, 4: 5 * 6}",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpAdd),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpMul),
+				code.Make(code.OpHash, 4),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTests(t, tests)
+}
+
 func parse(input string) *ast.Program {
 	l := lexer.New(input)
 	p := parser.New(l)

--- a/src/vm/vm.go
+++ b/src/vm/vm.go
@@ -152,12 +152,49 @@ func (vm *VM) Run() error {
 				return err
 			}
 
+		case code.OpHash:
+			numElements := int(code.ReadUint16(vm.instructions[ip+1:]))
+			ip += 2
+
+			hash, err := vm.buildHash(vm.sp-numElements, vm.sp)
+			if err != nil {
+				return err
+			}
+
+			vm.sp = vm.sp - numElements
+
+			err = vm.push(hash)
+			if err != nil {
+				return err
+			}
+
 		case code.OpPop:
 			vm.pop()
 
 		}
 	}
 	return nil
+}
+
+func (vm *VM) buildHash(startIndex, endIndex int) (object.Object, error) {
+	hashedPairs := make(map[object.HashKey]object.HashPair)
+
+	for i := startIndex; i < endIndex; i += 2 {
+		key := vm.stack[i]
+
+		value := vm.stack[i+1]
+
+		pair := object.HashPair{Key: key, Value: value}
+
+		hashKey, ok := key.(object.Hashable)
+		if !ok {
+			return nil, fmt.Errorf("unusable as hash key: %s", key.Type())
+		}
+
+		hashedPairs[hashKey.HashKey()] = pair
+	}
+
+	return &object.Hash{Pairs: hashedPairs}, nil
 }
 
 func (vm *VM) buildArray(startIndex, endIndex int) object.Object {

--- a/src/vm/vm.go
+++ b/src/vm/vm.go
@@ -196,6 +196,10 @@ func (vm *VM) executeBinaryOperation(op code.Opcode) error {
 		return vm.executeBinaryIntegerOperation(op, left, right)
 	}
 
+	if leftType == object.STRING_OBJ && rightType == object.STRING_OBJ {
+		return vm.executeBinaryStringOperation(op, left, right)
+	}
+
 	return fmt.Errorf("unsupported types for Binary operation: %s %s", leftType, rightType)
 }
 
@@ -227,6 +231,20 @@ func (vm *VM) executeBinaryIntegerOperation(
 	}
 
 	return vm.push(&object.Integer{Value: result})
+}
+
+func (vm *VM) executeBinaryStringOperation(
+	op code.Opcode,
+	left, right object.Object,
+) error {
+	if op != code.OpAdd {
+		return fmt.Errorf("unknown string operator: %d", op)
+	}
+
+	leftValue := left.(*object.String).Value
+	rightValue := right.(*object.String).Value
+
+	return vm.push(&object.String{Value: leftValue + rightValue})
 }
 
 // push() checks the stack size pushes an object onto the stack.

--- a/src/vm/vm_test.go
+++ b/src/vm/vm_test.go
@@ -102,6 +102,31 @@ func TestGlobalLetStatements(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestArrayLiterals(t *testing.T) {
+	tests := []vmTestCase{
+		{"[]", []int{}},
+		{"[1, 2, 3]", []int{1, 2, 3}},
+		{"[1 + 2, 3 * 4, 5 + 6]", []int{3, 12, 11}},
+	}
+	runVmTests(t, tests)
+}
+
+func TestIndexExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{"[1, 2, 3][1]", 2},
+		{"[1, 2, 3][0 + 2]", 3},
+		{"[[1, 1, 1]][0][0]", 1},
+		{"[][0]", Null},
+		{"[1, 2, 3][99]", Null},
+		{"[1][-1]", Null},
+		{"{1: 1, 2: 2}[1]", 1},
+		{"{1: 1, 2: 2}[2]", 2},
+		{"{1: 1}[0]", Null},
+		{"{}[0]", Null},
+	}
+	runVmTests(t, tests)
+}
+
 // parse() parses the input string and returns the AST.
 func parse(input string) *ast.Program {
 	l := lexer.New(input)
@@ -202,6 +227,28 @@ func testExpectedObject(
 		if err != nil {
 			t.Errorf("testStringObject failed: %s", err)
 		}
+
+	case []int:
+		array, ok := actual.(*object.Array)
+		if !ok {
+			t.Errorf("object not Array: %T (%+v)", actual, actual)
+			return
+		}
+		if len(array.Elements) != len(expected) {
+			t.Errorf("wrong num of elements. want=%d, got=%d",
+				len(expected), len(array.Elements))
+			return
+		}
+		for i, expectedElem := range expected {
+			err := testIntegerObject(int64(expectedElem), array.Elements[i])
+			if err != nil {
+				t.Errorf("testIntegerObject failed: %s", err)
+			}
+		}
+
+	// case map[object.HashKey]int64:
+	// 		hash, ok := actual.(*object.Hash)
+	// 		if !ok {}
 
 	case *object.Null:
 		if actual != Null {

--- a/src/vm/vm_test.go
+++ b/src/vm/vm_test.go
@@ -83,6 +83,15 @@ func TestConditionals(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestStringExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{`"chui"`, "chui"},
+		{`"ch" + "ui"`, "chui"},
+		{`"chui" + "eats" + "meat"`, "chuieatsmeat"},
+	}
+	runVmTests(t, tests)
+}
+
 func TestGlobalLetStatements(t *testing.T) {
 	tests := []vmTestCase{
 		{"let one = 1; one", 1},
@@ -188,6 +197,12 @@ func testExpectedObject(
 			t.Errorf("testBooleanObject failed: %s", err)
 		}
 
+	case string:
+		err := testStringObject(expected, actual)
+		if err != nil {
+			t.Errorf("testStringObject failed: %s", err)
+		}
+
 	case *object.Null:
 		if actual != Null {
 			t.Errorf("object is not Null: %T (%+v)", actual, actual)
@@ -195,4 +210,19 @@ func testExpectedObject(
 
 	}
 
+}
+
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+	if !ok {
+		return fmt.Errorf("object is not String. got=%T (%+v)",
+			actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%q, want=%q",
+			result.Value, expected)
+	}
+
+	return nil
 }

--- a/src/vm/vm_test.go
+++ b/src/vm/vm_test.go
@@ -127,6 +127,29 @@ func TestIndexExpressions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestHashLiterals(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			"{}", map[object.HashKey]int64{},
+		},
+		{
+			"{1: 2, 2: 3}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 1}).HashKey(): 2,
+				(&object.Integer{Value: 2}).HashKey(): 3,
+			},
+		},
+		{
+			"{1 + 1: 2 * 2, 3 + 3: 4 * 4}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 2}).HashKey(): 4,
+				(&object.Integer{Value: 6}).HashKey(): 16,
+			},
+		},
+	}
+	runVmTests(t, tests)
+}
+
 // parse() parses the input string and returns the AST.
 func parse(input string) *ast.Program {
 	l := lexer.New(input)


### PR DESCRIPTION
In this pull request, we are adding support for strings and string concatenation in the compiler and VM. This allows us to create and manipulate strings, arrays, and hashes in Chui. The changes include updates to the compiler and VM code to handle string literals and string expressions. We have also added tests to ensure the correct behavior of string operations.